### PR TITLE
Run redishappy-consul-service as redishappy:haproxy (instead of root:root) when using Upstart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - godep restore
 script: 
 - build/ci.sh
-- $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci -repotoken $GOVERALLS_TOKEN
+- $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci -repotoken=$GOVERALLS_TOKEN
 - build/release.sh
 env: 
   matrix: 

--- a/build/deb_upstart/redishappy-consul-service
+++ b/build/deb_upstart/redishappy-consul-service
@@ -7,6 +7,9 @@ stop on [!12345]
 respawn
 respawn limit 2 5
 
+setuid redishappy
+setgid haproxy
+
 umask 007
 
 script

--- a/build/local-scripts/postinstall-redishappy-consul
+++ b/build/local-scripts/postinstall-redishappy-consul
@@ -3,4 +3,4 @@
 set -eu
 
 chown -R root:root /etc/redishappy-consul
-chmod 640 /etc/redishappy-consul
+chmod 750 /etc/redishappy-consul

--- a/build/local-scripts/postinstall-redishappy-consul
+++ b/build/local-scripts/postinstall-redishappy-consul
@@ -2,9 +2,5 @@
 
 set -eu
 
-mkdir -p /var/log/redishappy-consul >/dev/null
-chown root:root /var/log/redishappy-consul >/dev/null
-chmod 750 /var/log/redishappy-consul >/dev/null
-
 chown -R root:root /etc/redishappy-consul
 chmod 640 /etc/redishappy-consul

--- a/build/local-scripts/postinstall-redishappy-consul
+++ b/build/local-scripts/postinstall-redishappy-consul
@@ -3,4 +3,4 @@
 set -eu
 
 chown -R root:root /etc/redishappy-consul
-chmod 750 /etc/redishappy-consul
+chmod 755 /etc/redishappy-consul


### PR DESCRIPTION
Tentative fix for #31 - haven't personally built a `.deb` with it yet.