### PR TITLE
Adding check for addgroup vs groupadd for different linux flavors

### DIFF
--- a/build/local-scripts/preinstall-redishappy-consul
+++ b/build/local-scripts/preinstall-redishappy-consul
@@ -13,7 +13,11 @@ fi
 
 if ! getent group $GROUP >/dev/null
 then
+    if type "groupadd" > /dev/null 2>&1; then
+        groupadd --system $GROUP >/dev/null
+    else
         addgroup --system $GROUP >/dev/null
+    fi
 fi
 
 # creating user if it isn't already there

--- a/build/local-scripts/preinstall-redishappy-haproxy
+++ b/build/local-scripts/preinstall-redishappy-haproxy
@@ -13,7 +13,11 @@ fi
 
 if ! getent group $GROUP >/dev/null
 then
+    if type "groupadd" > /dev/null 2>&1; then
+        groupadd --system $GROUP >/dev/null
+    else
         addgroup --system $GROUP >/dev/null
+    fi
 fi
 
 # creating user if it isn't already there


### PR DESCRIPTION
Hi,
Cool project!  We are running Centos 6 and the 'addgroup' does not work.  Just added a check for using 'groupadd' which usually exists. 
thanks.
-brandon