### PR TITLE
Readme improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,21 +150,17 @@ build/ci.sh
 
 Installing using the deb and rpm packages will set the following defaults -
 
-Installs to /usr/bin/redis-haproxy
-
-Configuration to /etc/redishappy-haproxy
-
-Logs to file in /var/log/redishappy-haproxy
-
-Warnings, Errors go to syslog
+* Installs to `/usr/bin/redis-haproxy`
+* Configuration to `/etc/redishappy-haproxy`
+* Logs to file in `/var/log/redishappy-haproxy`
+* Warnings, Errors go to syslog
 
 ### Configuration
 
 Example configurations can be found in the main folders
 
-[HAProxy](main/redis-haproxy)
-
-[Consul](main/redis-consul)
+* [HAProxy](main/redis-haproxy)
+* [Consul](main/redis-consul)
 
 Definitions for the elements
 
@@ -231,18 +227,15 @@ RedisHappy provides a readonly api on port 8000
 
 GET /api/ping - will reply "pong" if running
 
-GET /api/configuration - displays the start up configuration
-
-GET /api/sentinels - displays the sentinels being currently monitored and their current states
-
-GET /api/topology - displays the current view of the Redis clusters, their master and their host/ip addresses
+* `GET /api/ping` - will reply "pong" if running
+* `GET /api/configuration` - displays the start up configuration
+* `GET /api/sentinels` - displays the sentinels being currently monitored and their current states
+* `GET /api/topology` - displays the current view of the Redis clusters, their master and their host/ip addresses
 
 redishappy-haproxy provides the following additional read only apis
 
-GET /api/template - displays the current template file
-
-GET /api/haproxy - displays the rendered HAProxy file
-
+* `GET /api/template` - displays the current template file
+* `GET /api/haproxy` - displays the rendered HAProxy file
 
 ### Hacking
 
@@ -262,9 +255,10 @@ Thanks
 ------
 
 Big thanks to
-    - [Pierig Le Saux](https://github.com/lesaux) for providing the RPM packaging and Puppet expertise
-    - [Gary Hawkins](https://github.com/aeriandi-garyh) for providing the deb packaging expertise
-    - [Dominic Scheirlinck](https://github.com/dominics) for fixing up the consul deb package
+
+- [Pierig Le Saux](https://github.com/lesaux) for providing the RPM packaging and Puppet expertise
+- [Gary Hawkins](https://github.com/aeriandi-garyh) for providing the deb packaging expertise
+- [Dominic Scheirlinck](https://github.com/dominics) for fixing up the consul deb package
 
 
 Copyright and license

--- a/readme.md
+++ b/readme.md
@@ -248,9 +248,8 @@ GET /api/haproxy - displays the rendered HAProxy file
 
 Running the following script will gofmt, govet, run the tests, build all of the executables.
 
-```
-build/ci_script.sh
-
+```sh
+build/ci.sh
 ```
 
 ### Testing with Docker

--- a/readme.md
+++ b/readme.md
@@ -42,68 +42,68 @@ redishappy-consul updates entries in a Consul instance on Redis master promotion
 
 Q. Why - I thought in 2014 Redis clients should be Sentinel aware? They should connect to the correct Redis instance on failover.
 
-A. Some do, some don't. Some it seems to be an eternal 'work in progress'. Rather than fixing all of the clients we needed to work correctly with Sentinel, RedisHappy was built upon the fact that all of the clients I have tested are great at connecting to a single address. 
+A. Some do, some don't. Some it seems to be an eternal 'work in progress'. Rather than fixing all of the clients we needed to work correctly with Sentinel, RedisHappy was built upon the fact that all of the clients I have tested are great at connecting to a single address.
 
 Q. Why - Operations teams also need to support legacy applications and libraries - adding redishappy, Sentinels and HAProxy can help provide a HA enviroment for Redis backed applications.
 
-Q. Why - This [article](http://blog.haproxy.com/2014/01/02/haproxy-advanced-redis-health-check/) suggests that HAProxy can healthcheck Redis instances quite fine by itself. 
+Q. Why - This [article](http://blog.haproxy.com/2014/01/02/haproxy-advanced-redis-health-check/) suggests that HAProxy can healthcheck Redis instances quite fine by itself.
 
-A. Yes. It can do. But not reliably... I'll explain. 
+A. Yes. It can do. But not reliably... I'll explain.
 
-Suppose we have this setup. R1 and R2 are redis instances, S1,S2,S3 are Sentinel instances, H1 and H2 are HAProxy instances. 
+Suppose we have this setup. R1 and R2 are redis instances, S1,S2,S3 are Sentinel instances, H1 and H2 are HAProxy instances.
 
 <pre>
-	R1,R2
-	S1, S2, S3
-	H1, H2
+    R1,R2
+    S1, S2, S3
+    H1, H2
 </pre>
 
 - Life is good - R1 and R2 are in a master slave configuration, H1 and H2 correctly identify R1 as the master
 
 <pre>
-	R1      R2
-	M  ---- S
+    R1      R2
+    M  ---- S
     ^
     |
     ---------
     |       |
-	H1      H2
+    H1      H2
 </pre>
 
-- Disaster! - R1 dies or is partitioned but don't fear R2 is now the "master". Day saved! 
+- Disaster! - R1 dies or is partitioned but don't fear R2 is now the "master". Day saved!
 
 <pre>
-	*       R2
-			M
-    		^
+    *       R2
+            M
+            ^
             |
     ---------
     |       |
-	H1      H2
+    H1      H2
 </pre>
 
 - Disaster! - R1 comes back online and announces itself as a "master". Both R1 and R2 are now accepting writes, as HAProxy's healthcheck identifies both as online.
 
 <pre>
-	R1		R2
-	M       M
-    ^		^
+    R1        R2
+    M       M
+    ^        ^
     |       |
     ---------
-    |       |       
-	H1      H2
+    |       |
+    H1      H2
 </pre>
 
 - R1 is made the "slave" of R2. Everything is ok now, except for the writes that R1 accepted which are lost forever.
 
 <pre>
-	R1      R2
-	S ----- M
-    		^
+    R1      R2
+    S ----- M
+            ^
             |
     ---------
     |       |
-	H1      H2
+    H1      H2
 </pre>
 
 When a Redis instance is started and stopped it initially announces itself as a "master". It will some time later be made a "slave" but in the meantime accept writes which will be lost when it is correctly made a slave.
@@ -148,7 +148,7 @@ build/ci.sh
 
 ### Defaults
 
-Installing using the deb and rpm packages will set the following defaults - 
+Installing using the deb and rpm packages will set the following defaults -
 
 Installs to /usr/bin/redis-haproxy
 
@@ -178,7 +178,7 @@ Definitions for the elements
   }],
   // REQUIRED - needs to contain the details of at least one cluster
   // redishappy will discover additional sentinels as they come online
-  "Sentinels" : [ 
+  "Sentinels" : [
       {"Host" : "172.17.42.1", "Port" : 26377}
   ],
   // OPTIONAL for running redishappy-haproxy
@@ -193,21 +193,21 @@ Definitions for the elements
     },
     // OPTIONAL for running redishappy-consul
    "Consul" : {
-   	// REQUIRED - path to Consul instance
+       // REQUIRED - path to Consul instance
     "Address" : "127.0.0.1:8500",
     // REQUIRED - for each cluster in the main config there should be a defined service
-  	"Services" : [
-		{ 
-			// REQUIRED - should match a name of a Cluster in the main config
-			"Cluster" : "testing", 
-			// REQUIRED - logical name for the node
-        	"Node" : "redis-1",
-        	// REQUIRED - logical name for the data centre
-        	"Datacenter": "dc1",
-        	// REQUIRED - tags for the service
-        	"tags" : [ "redis", "master", "anothertag"]
-      	}
-  	]
+      "Services" : [
+        {
+            // REQUIRED - should match a name of a Cluster in the main config
+            "Cluster" : "testing",
+            // REQUIRED - logical name for the node
+            "Node" : "redis-1",
+            // REQUIRED - logical name for the data centre
+            "Datacenter": "dc1",
+            // REQUIRED - tags for the service
+            "tags" : [ "redis", "master", "anothertag"]
+          }
+      ]
   }
 }
 
@@ -217,8 +217,8 @@ Or you can configure with the following environmental variables -
 
 Environment Variable             | Example          | Notes
 ---------------------------------|------------------|-----------------------------------
-REDISHAPPY_CLUSTERS              | clustername:6379 | multiple values can be ; seperated 
-REDISHAPPY_SENTINELS             | ip_name:26377    | multiple values can be ; seperated 
+REDISHAPPY_CLUSTERS              | clustername:6379 | multiple values can be ; seperated
+REDISHAPPY_SENTINELS             | ip_name:26377    | multiple values can be ; seperated
 REDISHAPPY_HAPROXY_TEMPLATE_PATH |                  | string, see config file for example
 REDISHAPPY_HAPROXY_OUTPUT_PATH   |                  | string, see config file for example
 REDISHAPPY_HAPROXY_RELOAD_CMD    |                  | string, see config file for example
@@ -262,11 +262,11 @@ Will start up a master/slave, 3 sentinel redis cluster for testing.
 Thanks
 ------
 
-Big thanks to 
-	- [Pierig Le Saux](https://github.com/lesaux) for providing the RPM packaging and Puppet expertise 
-	- [Gary Hawkins](https://github.com/aeriandi-garyh) for providing the deb packaging expertise
-	- [Dominic Scheirlinck](https://github.com/dominics) for fixing up the consul deb package
-	
+Big thanks to
+    - [Pierig Le Saux](https://github.com/lesaux) for providing the RPM packaging and Puppet expertise
+    - [Gary Hawkins](https://github.com/aeriandi-garyh) for providing the deb packaging expertise
+    - [Dominic Scheirlinck](https://github.com/dominics) for fixing up the consul deb package
+
 
 Copyright and license
 ---------------------

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Using Vagrant
 
 The provided vagrant file creates a virtual machine with all of the dependancies to build redishappy, smoke test it, and build the deb and rpm packages.
 
-```
+```sh
 vagrant up
 ```
 
@@ -128,7 +128,7 @@ Download and build.
 
 Install golang 1.4 +
 
-```
+```sh
 go get github.com/mdevilliers/redishappy
 
 cd $GOPATH/src/github.com/redishappy
@@ -168,7 +168,7 @@ Example configurations can be found in the main folders
 
 Definitions for the elements
 
-```Javascript
+```js
 {
   // REQUIRED - needs to contain at least one logical cluster
   "Clusters" :[

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Features
 
 Redishappy ships in two forms redishappy-haproxy and redishappy-consul.
 
-####redishappy-haproxy
+#### redishappy-haproxy
 
 redishappy-haproxy updates HAProxy's configuration file on Redis master promotion and then reloads the HAProxy configuration file. The reload maintains current connections.
 
@@ -31,7 +31,7 @@ redishappy-haproxy updates HAProxy's configuration file on Redis master promotio
 
 The redishappy daemon is installed on the same machine as HAProxy and runs with correct user rights to interact with HAProxy. Multiple instance of HAProxy/redishappy-haproxy can be deployed and operate seperatly.
 
-####redishappy-consul
+#### redishappy-consul
 
 redishappy-consul updates entries in a Consul instance on Redis master promotion.
 
@@ -44,7 +44,7 @@ Q. Why - I thought in 2014 Redis clients should be Sentinel aware? They should c
 
 A. Some do, some don't. Some it seems to be an eternal 'work in progress'. Rather than fixing all of the clients we needed to work correctly with Sentinel, RedisHappy was built upon the fact that all of the clients I have tested are great at connecting to a single address.
 
-Q. Why - Operations teams also need to support legacy applications and libraries - adding redishappy, Sentinels and HAProxy can help provide a HA enviroment for Redis backed applications.
+Operations teams also need to support legacy applications and libraries - adding redishappy, Sentinels and HAProxy can help provide a HA enviroment for Redis backed applications.
 
 Q. Why - This [article](http://blog.haproxy.com/2014/01/02/haproxy-advanced-redis-health-check/) suggests that HAProxy can healthcheck Redis instances quite fine by itself.
 
@@ -145,7 +145,6 @@ godep restore
 build/ci.sh
 ```
 
-
 ### Defaults
 
 Installing using the deb and rpm packages will set the following defaults -
@@ -211,21 +210,19 @@ Definitions for the elements
 
 Or you can configure with the following environmental variables -
 
-Environment Variable             | Example          | Notes
----------------------------------|------------------|-----------------------------------
-REDISHAPPY_CLUSTERS              | clustername:6379 | multiple values can be ; seperated
-REDISHAPPY_SENTINELS             | ip_name:26377    | multiple values can be ; seperated
-REDISHAPPY_HAPROXY_TEMPLATE_PATH |                  | string, see config file for example
-REDISHAPPY_HAPROXY_OUTPUT_PATH   |                  | string, see config file for example
-REDISHAPPY_HAPROXY_RELOAD_CMD    |                  | string, see config file for example
+Environment Variable               | Example          | Notes
+-----------------------------------|------------------|-----------------------------------
+`REDISHAPPY_CLUSTERS`              | clustername:6379 | multiple values can be ; seperated
+`REDISHAPPY_SENTINELS`             | ip_name:26377    | multiple values can be ; seperated
+`REDISHAPPY_HAPROXY_TEMPLATE_PATH` |                  | string, see config file for example
+`REDISHAPPY_HAPROXY_OUTPUT_PATH`   |                  | string, see config file for example
+`REDISHAPPY_HAPROXY_RELOAD_CMD`    |                  | string, see config file for example
 
 
 
-### Api
+### API
 
-RedisHappy provides a readonly api on port 8000
-
-GET /api/ping - will reply "pong" if running
+RedisHappy provides a readonly API on port 8000. You can change the port by specifying a `PORT` environment variable.
 
 * `GET /api/ping` - will reply "pong" if running
 * `GET /api/configuration` - displays the start up configuration


### PR DESCRIPTION
Main rationale behind this was to mention that the `PORT` environment variable can be used to change the API port. This just seems to be the default behaviour of goji, but it's really useful if you need to run Redishappy on a machine that's already using 8000 for something else.

The other changes are:
 - Fixing lists to show up correctly
 - Normalizing whitespace (went with unix line endings, hope that's OK), fixing mixed tabs and spaces
 - Changing a mention of `build/ci_script.sh` to `build/ci.sh`

Compare https://github.com/dominics/redishappy/tree/bugfix-readme#api with https://github.com/mdevilliers/redishappy/tree/master#api