### PR TITLE
Redis OS TCP Keepalive

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -15,11 +15,11 @@
 		},
 		{
 			"ImportPath": "github.com/therealbill/libredis/client",
-			"Rev": "6539abbacf1e3e8526c06394d264581841ecfe9e"
+			"Rev": "a48fa9547817823dc64561bf3fe82a11dcef8b14"
 		},
 		{
 			"ImportPath": "github.com/therealbill/libredis/info",
-			"Rev": "6539abbacf1e3e8526c06394d264581841ecfe9e"
+			"Rev": "a48fa9547817823dc64561bf3fe82a11dcef8b14"
 		},
 		{
 			"ImportPath": "github.com/zenazn/goji",

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -19,10 +19,11 @@ type ConfigurationManager struct {
 }
 
 type Configuration struct {
-	Clusters  []types.Cluster  `json:"clusters"`
-	Sentinels []types.Sentinel `json:"sentinels"`
-	Consul    types.Consul     `json:"consul,omitempty"`
-	HAProxy   types.HAProxy    `json:"HAProxy,omitempty"`
+	SentinelTCPKeepAlive int              `json:"SentinelTCPKeepAlive"`
+	Clusters             []types.Cluster  `json:"clusters"`
+	Sentinels            []types.Sentinel `json:"sentinels"`
+	Consul               types.Consul     `json:"consul,omitempty"`
+	HAProxy              types.HAProxy    `json:"HAProxy,omitempty"`
 }
 
 type GetConfigCommand struct {

--- a/main/noop/config.json
+++ b/main/noop/config.json
@@ -1,4 +1,5 @@
 {
+  "SentinelTCPKeepAlive": 0,
   "Clusters" :[
   {
     "Name" : "testing",

--- a/main/redis-consul/config.json
+++ b/main/redis-consul/config.json
@@ -1,4 +1,5 @@
 {
+  "SentinelTCPKeepAlive": 0,
   "Clusters" :[
   {
     "Name" : "testing",

--- a/main/redis-haproxy/config.json
+++ b/main/redis-haproxy/config.json
@@ -1,4 +1,5 @@
 {
+  "SentinelTCPKeepAlive": 0,
   "Clusters" :[
   {
     "Name" : "testing",

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,8 @@ Definitions for the elements
 
 ```js
 {
+  // OPTIONAL - TCP Keep-Alive time (in seconds)
+  "SentinelTCPKeepAlive" : 0
   // REQUIRED - needs to contain at least one logical cluster
   "Clusters" :[
   {

--- a/sentinel/manager.go
+++ b/sentinel/manager.go
@@ -95,7 +95,7 @@ func (m *SentinelManager) getTopology(stateChannel chan types.MasterDetailsColle
 	configuration := m.configurationManager.GetCurrentConfiguration()
 
 	for _, sentinel := range configuration.Sentinels {
-		client, err := redis.NewSentinelClient(sentinel, m.redisConnection)
+		client, err := redis.NewSentinelClient(sentinel, m.redisConnection, 13)
 
 		if err != nil {
 			logger.Info.Printf("Error starting sentinel (%s) client : %s", sentinel.GetLocation(), err.Error())

--- a/sentinel/manager.go
+++ b/sentinel/manager.go
@@ -73,7 +73,7 @@ func (m *SentinelManager) GetCurrentTopology() types.MasterDetailsCollection {
 
 func (m *SentinelManager) startNewMonitor(sentinel types.Sentinel) {
 
-	monitor, err := NewMonitor(sentinel, m, m.redisConnection)
+	monitor, err := NewMonitor(sentinel, m, m.redisConnection, m.configurationManager.GetCurrentConfiguration().SentinelTCPKeepAlive)
 
 	if err != nil {
 		logger.Error.Printf("Error starting monitor %s : %s", sentinel.GetLocation(), err.Error())
@@ -95,7 +95,7 @@ func (m *SentinelManager) getTopology(stateChannel chan types.MasterDetailsColle
 	configuration := m.configurationManager.GetCurrentConfiguration()
 
 	for _, sentinel := range configuration.Sentinels {
-		client, err := redis.NewSentinelClient(sentinel, m.redisConnection, 13)
+		client, err := redis.NewSentinelClient(sentinel, m.redisConnection, configuration.SentinelTCPKeepAlive)
 
 		if err != nil {
 			logger.Info.Printf("Error starting sentinel (%s) client : %s", sentinel.GetLocation(), err.Error())

--- a/sentinel/monitor.go
+++ b/sentinel/monitor.go
@@ -25,13 +25,13 @@ func NewMonitor(sentinel types.Sentinel, manager Manager, redisConnection redis.
 	uri := sentinel.GetLocation()
 
 	channel := make(chan redis.RedisPubSubReply)
-	pubSubClient, err := redis.NewPubSubClient(uri, channel, redisConnection)
+	pubSubClient, err := redis.NewPubSubClient(uri, channel, redisConnection, 15)
 
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := redis.NewSentinelClient(sentinel, redisConnection)
+	client, err := redis.NewSentinelClient(sentinel, redisConnection, 14)
 
 	if err != nil {
 		return nil, err

--- a/sentinel/monitor.go
+++ b/sentinel/monitor.go
@@ -20,18 +20,18 @@ type Monitor struct {
 	redisConnection redis.RedisConnection
 }
 
-func NewMonitor(sentinel types.Sentinel, manager Manager, redisConnection redis.RedisConnection) (*Monitor, error) {
+func NewMonitor(sentinel types.Sentinel, manager Manager, redisConnection redis.RedisConnection, tcp_keepalive int) (*Monitor, error) {
 
 	uri := sentinel.GetLocation()
 
 	channel := make(chan redis.RedisPubSubReply)
-	pubSubClient, err := redis.NewPubSubClient(uri, channel, redisConnection, 15)
+	pubSubClient, err := redis.NewPubSubClient(uri, channel, redisConnection, tcp_keepalive)
 
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := redis.NewSentinelClient(sentinel, redisConnection, 14)
+	client, err := redis.NewSentinelClient(sentinel, redisConnection, tcp_keepalive)
 
 	if err != nil {
 		return nil, err

--- a/sentinel/monitor.go
+++ b/sentinel/monitor.go
@@ -20,18 +20,18 @@ type Monitor struct {
 	redisConnection redis.RedisConnection
 }
 
-func NewMonitor(sentinel types.Sentinel, manager Manager, redisConnection redis.RedisConnection, tcp_keepalive int) (*Monitor, error) {
+func NewMonitor(sentinel types.Sentinel, manager Manager, redisConnection redis.RedisConnection, tcpKeepAlive int) (*Monitor, error) {
 
 	uri := sentinel.GetLocation()
 
 	channel := make(chan redis.RedisPubSubReply)
-	pubSubClient, err := redis.NewPubSubClient(uri, channel, redisConnection, tcp_keepalive)
+	pubSubClient, err := redis.NewPubSubClient(uri, channel, redisConnection, tcpKeepAlive)
 
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := redis.NewSentinelClient(sentinel, redisConnection, tcp_keepalive)
+	client, err := redis.NewSentinelClient(sentinel, redisConnection, tcpKeepAlive)
 
 	if err != nil {
 		return nil, err

--- a/services/redis/pubsubclient.go
+++ b/services/redis/pubsubclient.go
@@ -10,9 +10,9 @@ type PubSubClient struct {
 	channel            chan RedisPubSubReply
 }
 
-func NewPubSubClient(url string, channel chan RedisPubSubReply, redisConnection RedisConnection) (*PubSubClient, error) {
+func NewPubSubClient(url string, channel chan RedisPubSubReply, redisConnection RedisConnection, tcp_keepalive int) (*PubSubClient, error) {
 
-	client, err := redisConnection.GetConnection("tcp", url)
+	client, err := redisConnection.GetConnection("tcp", url, tcp_keepalive)
 
 	if err != nil {
 		logger.Error.Printf("PubSubClient Error connecting to %s : %s", url, err.Error())

--- a/services/redis/pubsubclient.go
+++ b/services/redis/pubsubclient.go
@@ -10,9 +10,9 @@ type PubSubClient struct {
 	channel            chan RedisPubSubReply
 }
 
-func NewPubSubClient(url string, channel chan RedisPubSubReply, redisConnection RedisConnection, tcp_keepalive int) (*PubSubClient, error) {
+func NewPubSubClient(url string, channel chan RedisPubSubReply, redisConnection RedisConnection, tcpKeepAlive int) (*PubSubClient, error) {
 
-	client, err := redisConnection.GetConnection("tcp", url, tcp_keepalive)
+	client, err := redisConnection.GetConnection("tcp", url, tcpKeepAlive)
 
 	if err != nil {
 		logger.Error.Printf("PubSubClient Error connecting to %s : %s", url, err.Error())

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -17,12 +17,12 @@ type Redis interface {
 	GetConnection(protocol, uri string, tcp_keepalive int) (RedisClient, error)
 }
 
-func (RedisConnection) GetConnection(protocol, uri string, tcp_keepalive int) (RedisClient, error) {
+func (RedisConnection) GetConnection(protocol, uri string, tcpKeepAlive int) (RedisClient, error) {
 	client, err := client.DialWithConfig(&client.DialConfig{
 		Network:      protocol,
 		Address:      uri,
 		Timeout:      RedisConnectionTimeoutPeriod,
-		TCPKeepAlive: tcp_keepalive,
+		TCPKeepAlive: tcpKeepAlive,
 	})
 
 	return client, err

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -13,14 +13,17 @@ const (
 type RedisConnection struct{}
 
 type Redis interface {
-	GetConnection(protocol, uri string) (RedisClient, error)
+	GetConnection(protocol, uri string, tcp_keepalive int) (RedisClient, error)
 }
 
-func (RedisConnection) GetConnection(protocol, uri string) (RedisClient, error) {
+func (RedisConnection) GetConnection(protocol, uri string, tcp_keepalive int) (RedisClient, error) {
 	client, err := client.DialWithConfig(&client.DialConfig{
-		Network: protocol,
-		Address: uri,
-		Timeout: RedisConnectionTimeoutPeriod})
+		Network:      protocol,
+		Address:      uri,
+		Timeout:      RedisConnectionTimeoutPeriod,
+		TCPKeepAlive: tcp_keepalive,
+	})
+
 	return client, err
 }
 

--- a/services/redis/sentinelclient.go
+++ b/services/redis/sentinelclient.go
@@ -10,11 +10,11 @@ type SentinelClient struct {
 	redisClient RedisClient
 }
 
-func NewSentinelClient(sentinel types.Sentinel, redisConnection RedisConnection, tcp_keepalive int) (*SentinelClient, error) {
+func NewSentinelClient(sentinel types.Sentinel, redisConnection RedisConnection, tcpKeepAlive int) (*SentinelClient, error) {
 
 	uri := sentinel.GetLocation()
 
-	redisclient, err := redisConnection.GetConnection("tcp", uri, tcp_keepalive)
+	redisclient, err := redisConnection.GetConnection("tcp", uri, tcpKeepAlive)
 
 	if err != nil {
 		logger.Info.Printf("SentinelClient : not connected to %s, %s", uri, err.Error())

--- a/services/redis/sentinelclient.go
+++ b/services/redis/sentinelclient.go
@@ -10,11 +10,11 @@ type SentinelClient struct {
 	redisClient RedisClient
 }
 
-func NewSentinelClient(sentinel types.Sentinel, redisConnection RedisConnection) (*SentinelClient, error) {
+func NewSentinelClient(sentinel types.Sentinel, redisConnection RedisConnection, tcp_keepalive int) (*SentinelClient, error) {
 
 	uri := sentinel.GetLocation()
 
-	redisclient, err := redisConnection.GetConnection("tcp", uri)
+	redisclient, err := redisConnection.GetConnection("tcp", uri, tcp_keepalive)
 
 	if err != nil {
 		logger.Info.Printf("SentinelClient : not connected to %s, %s", uri, err.Error())


### PR DESCRIPTION
Requires the latest `libredis` dependancy, that supports the keepalive options, which has now been merged :) https://github.com/therealbill/libredis/pull/9

You may want to enable this for long-lived quiet connections (such as Sentinel connections that can hang around for months) that you want to ensure remain connected. Such as a PUBSUB, where Redis application `PING` commands aren't necessarily available. 

Intermediate routers or NAT devices (eg, in an AWS VPC) may silently drop these long-lived connections after a period of time, and RedisHappy will just never notice. Potentially missing `+switch-master` events. The SYN/ACK mechanism will attempt to keep these connections alive, and also a provide a way for detecting a problem.

This is very much a last-chance ability to catch a connection failure. The OS will eventually drop the connection, and will (eventually) bubble up as a TCP connection failure that we can deal with, and perhaps try reconnecting/re-syncing.

Example error on the PUB/SUB connection after KeepAlive has decided that the connection is dead:
```
INFO: 2016/03/09 23:24:04 monitor.go:X: Subscription Message :  : Error read tcp 10.10.10.5:26379: connection timed out
```
