### PR TITLE
Re-sync topology upon PUBSUB connection

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -23,7 +23,6 @@ func NewRedisHappyEngine(flipper types.FlipperClient, cm *configuration.Configur
 	sentinelManager := sentinel.NewManager(masterEvents, cm)
 
 	go loopSentinelEvents(flipper, masterEvents)
-	go intiliseTopology(flipper, sentinelManager)
 
 	return &RedisHappyEngine{
 		cm: cm,

--- a/sentinel/manager.go
+++ b/sentinel/manager.go
@@ -120,9 +120,7 @@ func (m *SentinelManager) receiveConnectionMessage(in chan types.ConnectionEvent
 					}
 
 					out <- resyncMasterSwitchEvent
-
 				}
-
 			}
 		}
 	}

--- a/sentinel/monitor.go
+++ b/sentinel/monitor.go
@@ -115,6 +115,7 @@ L:
 func (m *Monitor) shutDownMonitor() {
 	logger.Info.Printf("Shutting down monitor %s", m.sentinel.GetLocation())
 	m.manager.Notify(&SentinelLost{Sentinel: m.sentinel})
+	m.client.Close()
 	m.pubSubClient.Close()
 }
 

--- a/sentinel/monitor.go
+++ b/sentinel/monitor.go
@@ -142,8 +142,10 @@ func dealWithSentinelMessage(message redis.RedisPubSubReply, switchmasterchannel
 
 	// If we've sucessfully subscribed, let the manager know, so it can force a topology resync.
 	if message.MessageType() == redis.Confirmation {
-		logger.Trace.Println("Subscription Message : Firing a ConnectionEvent")
-		connectionChannel <- types.ConnectionEvent{Connected: true}
+		if message.Message() == "1" {
+			logger.Trace.Println("Subscription Message : Firing a ConnectionEvent")
+			connectionChannel <- types.ConnectionEvent{Connected: true}
+		}
 	}
 
 	return false

--- a/sentinel/monitor.go
+++ b/sentinel/monitor.go
@@ -143,8 +143,12 @@ func dealWithSentinelMessage(message redis.RedisPubSubReply, switchmasterchannel
 	// If we've sucessfully subscribed, let the manager know, so it can force a topology resync.
 	if message.MessageType() == redis.Confirmation {
 		if message.Message() == "1" {
+			// We should expect a value of 1 here (appears to be a subscription counter)
 			logger.Trace.Println("Subscription Message : Firing a ConnectionEvent")
 			connectionChannel <- types.ConnectionEvent{Connected: true}
+		} else {
+			// Something odd has occurred. We're not guarantted to be subscribed.
+			return true
 		}
 	}
 

--- a/sentinel/monitor_test.go
+++ b/sentinel/monitor_test.go
@@ -76,9 +76,9 @@ func TestMonitorWillParseSubscribeConfirmation(t *testing.T) {
 		}
 	}()
 
-	connection_event := <-connectionChannel
-	if connection_event.Connected != true {
-		t.Error("Error receiving connection event")
+	connectionEvent := <-connectionChannel
+	if connectionEvent.Connected != true {
+		t.Error("Error receiving connectionEvent")
 	}
 
 }

--- a/sentinel/monitor_test.go
+++ b/sentinel/monitor_test.go
@@ -64,6 +64,39 @@ func TestMonitorWillReturnFalseOnAnInvalidMessage(t *testing.T) {
 	}
 }
 
+func TestMonitorWillParseSubscribeConfirmation(t *testing.T) {
+
+	connectionChannel := make(chan types.ConnectionEvent)
+	switchmasterchannel := make(chan types.MasterSwitchedEvent)
+	unthrottled := make(chan types.MasterSwitchedEvent)
+	validinput := "1"
+
+	go func() {
+		ok := dealWithSentinelMessage(&MockMessage{messageType: redis.Confirmation, messages: validinput}, switchmasterchannel, connectionChannel)
+		if ok {
+			t.Error("A valid subscription message was passed")
+		}
+	}()
+
+	connection_event := <-connectionChannel
+	if connection_event.Connected != true {
+		t.Error("Error receiving connection event")
+	}
+
+}
+
+func TestMonitorWillReturnFalseOnAnInvalidSubscribeConfirmation(t *testing.T) {
+
+	connectionChannel := make(chan types.ConnectionEvent)
+	switchmasterchannel := make(chan types.MasterSwitchedEvent)
+	invalidinput := "2"
+
+	ok := dealWithSentinelMessage(&MockMessage{messageType: redis.Confirmation, messages: invalidinput}, switchmasterchannel, connectionChannel)
+	if !ok {
+		t.Error("An invalid subscription message was passed")
+	}
+}
+
 func TestParseMasterMessage(t *testing.T) {
 
 	input := "name 1.1.1.1 1234 2.2.2.2 5678"

--- a/sentinel/monitor_test.go
+++ b/sentinel/monitor_test.go
@@ -35,7 +35,6 @@ func TestMonitorWillParseAndForwardOnAGoodMessage(t *testing.T) {
 
 	connectionChannel := make(chan types.ConnectionEvent)
 	switchmasterchannel := make(chan types.MasterSwitchedEvent)
-	unthrottled := make(chan types.MasterSwitchedEvent)
 	validinput := "name 1.1.1.1 1234 2.2.2.2 5678"
 
 	go func() {
@@ -68,7 +67,6 @@ func TestMonitorWillParseSubscribeConfirmation(t *testing.T) {
 
 	connectionChannel := make(chan types.ConnectionEvent)
 	switchmasterchannel := make(chan types.MasterSwitchedEvent)
-	unthrottled := make(chan types.MasterSwitchedEvent)
 	validinput := "1"
 
 	go func() {

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -62,9 +62,8 @@ func NewRedisPubSubReply(message []string, err error) RedisPubSubReply {
 		channel: message[1],
 	}
 
-	if message[0] == "subcribe" {
+	if message[0] == "subscribe" {
 		ret.messageType = Confirmation
-		return ret
 	}
 
 	if message[0] == "message" {

--- a/types/flipper.go
+++ b/types/flipper.go
@@ -1,5 +1,9 @@
 package types
 
+type ConnectionEvent struct {
+	Connected bool
+}
+
 type MasterSwitchedEvent struct {
 	Name          string
 	OldMasterIp   string


### PR DESCRIPTION
As soon as we make a PUB/SUB connection, we should retrieve the current topology, to ensure the flipper_client is up-to-date. 

If for any reason we loose connectivity (such as a detectable TCP failure), this ensures any missed `+switch-master` events can be mitigated. 

This works by
- creating a new channel between the Manager <= Monitor.
- firing a `ConnectionEvent` upon confirmation of `SUBSCRIBE +switch-master`
- The Manger will then fetch the current topology
- Inject `MasterSwitchedEvent` into the unthrottled `connectionChannel`

This means we can also remove the startup `intiliseTopology()`, as we know that same kind of event will take place upon any sentinel connection now.

The various flapper_clients will likely start to receive more events (depending on your Cluster + Sentinel count), but being consistent and reliable is the key here.


 