### PR TITLE
fixes for compilation on Solaris/SmartOS, other platforms

### DIFF
--- a/build/ci.sh
+++ b/build/ci.sh
@@ -10,10 +10,13 @@
 set -e
 
 # Automatic checks
+RACE_FLAG="-race"
+if [[ `uname` == "SunOS" ]]; then RACE_FLAG=""; fi
+
 test -z "$(gofmt -l -w .     | tee /dev/stderr)"
 test -z "$(goimports -w .    | tee /dev/stderr)"
 godep go vet ./...
-godep go test -race ./...
+godep go test $RACE_FLAG ./...
 
 # Run test coverage on each subdirectories and merge the coverage profile. 
 echo "mode: count" > profile.cov

--- a/services/logger/default.go
+++ b/services/logger/default.go
@@ -24,6 +24,8 @@ func init() {
 	NoteWorthy = log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
 }
 
+func InitLogging(logPath string) {}
+
 func newLogFileWriter(logPath string) io.Writer {
 
 	return &lumberjack.Logger{


### PR DESCRIPTION
Hello,

RedisHappy works great, with all tests passing, on Joyent's SmartOS (Solaris).  It just took two minor changes.  `-race` flag is not supported on Solaris, and InitLogging was missing from the default logger.

Thanks for your work!